### PR TITLE
emit elements for skipped tests

### DIFF
--- a/lib/xunit-file.js
+++ b/lib/xunit-file.js
@@ -49,6 +49,10 @@ function XUnitFile(runner) {
     tests.push(test);
   });
 
+  runner.on('pending', function(test) {
+      tests.push(test);
+  });
+
   runner.on('end', function(){
     
     appendLine(tag('testsuite', {
@@ -89,6 +93,7 @@ function test(test) {
     attrs.message = escape(err.message);
     appendLine(tag('testcase', attrs, false, tag('failure', attrs, false, cdata(err.stack))));
   } else if (test.pending) {
+    delete attrs.time;
     appendLine(tag('testcase', attrs, false, tag('skipped', {}, true)));
   } else {
     appendLine(tag('testcase', attrs, true) );


### PR DESCRIPTION
The current version of the reporter emits the # of skipped tests for the suite, but it doesn't emit individual lines for each skipped test. This makes some tools (notably: Jenkins) not notice that the suite contains skipped tests.
