### PR TITLE
Rename the 'skip' tag to 'skipped' to match the standard output.

### DIFF
--- a/lib/xunit-file.js
+++ b/lib/xunit-file.js
@@ -75,7 +75,7 @@ function XUnitFile(runner) {
       , tests: stats.tests
       , failures: stats.failures
       , errors: stats.failures
-      , skip: stats.tests - stats.failures - stats.passes
+      , skipped: stats.tests - stats.failures - stats.passes
       , timestamp: (new Date).toUTCString()
       , time: stats.duration / 1000
     }, false));


### PR DESCRIPTION
The xunit.xml couldn't work well with jenkins xunit-plugin. So make it right.
