### PR TITLE
Optionally set suite name from environment variable

### DIFF
--- a/lib/xunit-file.js
+++ b/lib/xunit-file.js
@@ -71,7 +71,7 @@ function XUnitFile(runner) {
   runner.on('end', function(){
     
     appendLine(tag('testsuite', {
-        name: 'Mocha Tests'
+        name: process.env.SUITE_NAME || 'Mocha Tests'
       , tests: stats.tests
       , failures: stats.failures
       , errors: stats.failures


### PR DESCRIPTION
My use case is that I am running the same tests in different browsers, and so it would be useful for reporting to have the suites named "IE 11" and "Firefox 33", etc.
