### PR TITLE
Feature/mkdirp output dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ results
 
 node_modules
 npm-debug.log
+
+_tmp

--- a/lib/xunit-file.js
+++ b/lib/xunit-file.js
@@ -8,8 +8,9 @@ var mocha = require("mocha")
   , escape = utils.escape
   , config = require("../config.json")
   , fs = require("fs")
+  , path = require("path")
+  , mkdirp = require("mkdirp")
   , filePath = process.env.XUNIT_FILE || config.file || process.cwd() + "/xunit.xml"
-  , fd = fs.openSync(filePath, 'w', 0755)
   , consoleOutput = config.consoleOutput || {};
 
 /**
@@ -39,7 +40,10 @@ function XUnitFile(runner) {
   Base.call(this, runner);
   var stats = this.stats
     , tests = []
-    , self = this;
+    , fd;
+
+  mkdirp.sync(path.dirname(filePath));
+  fd = fs.openSync(filePath, 'w', 0755);
 
   runner.on('suite', function(suite){
     if(consoleOutput.suite){
@@ -70,7 +74,7 @@ function XUnitFile(runner) {
 
   runner.on('end', function(){
     
-    appendLine(tag('testsuite', {
+    appendLine(fd, tag('testsuite', {
         name: process.env.SUITE_NAME || 'Mocha Tests'
       , tests: stats.tests
       , failures: stats.failures
@@ -80,8 +84,11 @@ function XUnitFile(runner) {
       , time: stats.duration / 1000
     }, false));
 
-    tests.forEach(test);
-    appendLine('</testsuite>');
+    tests.forEach(function(test){
+      writeTest(fd, test);
+    });
+
+    appendLine(fd, '</testsuite>');
     fs.closeSync(fd);
   });
 }
@@ -96,7 +103,7 @@ XUnitFile.prototype.__proto__ = Base.prototype;
  * Output tag for the given `test.`
  */
 
-function test(test) {
+function writeTest(fd, test) {
   var attrs = {
       classname: test.parent.fullTitle()
     , name: test.title
@@ -106,12 +113,12 @@ function test(test) {
 
   if ('failed' == test.state) {
     var err = test.err;
-    appendLine(tag('testcase', attrs, false, tag('failure', { message: escape(err.message) }, false, cdata(err.stack))));
+    appendLine(fd, tag('testcase', attrs, false, tag('failure', { message: escape(err.message) }, false, cdata(err.stack))));
   } else if (test.pending) {
     delete attrs.time;
-    appendLine(tag('testcase', attrs, false, tag('skipped', {}, true)));
+    appendLine(fd, tag('testcase', attrs, false, tag('skipped', {}, true)));
   } else {
-    appendLine(tag('testcase', attrs, true) );
+    appendLine(fd, tag('testcase', attrs, true) );
   }
 }
 
@@ -122,15 +129,15 @@ function test(test) {
 function tag(name, attrs, close, content) {
   var end = close ? '/>' : '>'
     , pairs = []
-    , tag;
+    , result;
 
   for (var key in attrs) {
     pairs.push(key + '="' + escape(attrs[key]) + '"');
   }
 
-  tag = '<' + name + (pairs.length ? ' ' + pairs.join(' ') : '') + end;
-  if (content) tag += content + '</' + name + end;
-  return tag;
+  result = '<' + name + (pairs.length ? ' ' + pairs.join(' ') : '') + end;
+  if (content) result += content + '</' + name + end;
+  return result;
 }
 
 /**
@@ -141,7 +148,7 @@ function cdata(str) {
   return '<![CDATA[' + escape(str) + ']]>';
 }
 
-function appendLine(line) {
+function appendLine(fd, line) {
     if (process.env.LOG_XUNIT) {
         console.log(line);
     }

--- a/package.json
+++ b/package.json
@@ -1,21 +1,41 @@
 {
-    "name": "xunit-file",
-    "description": "Basically the same reporter as mocha's xunit reporter, but writes the output in a file.",
-    "version": "0.0.7",
-    "author": {
-        "name": "Matthias Jahn",
-        "email": "matthias.jahn@peerigon.com"
+  "name": "xunit-file",
+  "description": "Basically the same reporter as mocha's xunit reporter, but writes the output in a file.",
+  "version": "0.0.7",
+  "author": {
+    "name": "Matthias Jahn",
+    "email": "matthias.jahn@peerigon.com"
+  },
+  "contributors": [
+    {
+      "name": "Matthias Jahn",
+      "email": "matthias.jahn@peerigon.com"
     },
-    "contributors": [
-        { "name": "Matthias Jahn", "email": "matthias.jahn@peerigon.com" },
-        { "name": "Paul Torka", "email": "paul.torka@yahoo.de" },
-        { "name": "Peter Janes", "email": "peter.janes@ek3.com" }
-    ],    
-    "keywords" : ["mocha", "xunit", "file", "reporter"],
-    "main" : "lib/xunit-file.js",
-    "repository" : "git://github.com/peerigon/xunit-file.git",
-    "license": "MIT",
-    "dependencies": {
-        "mkdirp": "^0.5.1"
+    {
+      "name": "Paul Torka",
+      "email": "paul.torka@yahoo.de"
+    },
+    {
+      "name": "Peter Janes",
+      "email": "peter.janes@ek3.com"
     }
+  ],
+  "keywords": [
+    "mocha",
+    "xunit",
+    "file",
+    "reporter"
+  ],
+  "main": "lib/xunit-file.js",
+  "repository": "git://github.com/peerigon/xunit-file.git",
+  "license": "MIT",
+  "dependencies": {
+    "mkdirp": "^0.5.1"
+  },
+  "devDependencies": {
+    "mocha": "^2.2.5"
+  },
+  "scripts": {
+    "test": "rm -rf _tmp && mocha test/*.spec.js"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "xunit-file",
     "description": "Basically the same reporter as mocha's xunit reporter, but writes the output in a file.",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "author": {
         "name": "Matthias Jahn",
         "email": "matthias.jahn@peerigon.com"
@@ -14,6 +14,8 @@
     "keywords" : ["mocha", "xunit", "file", "reporter"],
     "main" : "lib/xunit-file.js",
     "repository" : "git://github.com/peerigon/xunit-file.git",
-    "license": "MIT"
-    
+    "license": "MIT",
+    "dependencies": {
+        "mkdirp": "^0.5.1"
+    }
 }

--- a/test/fixture/success/success.spec.js
+++ b/test/fixture/success/success.spec.js
@@ -1,0 +1,5 @@
+describe("Success Suite", function () {
+    it("should pass", function (done) {
+        done();
+    });
+});

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -1,0 +1,23 @@
+var spawn = require('child_process').spawn
+  , mochaBin = require.resolve('mocha/bin/_mocha')
+
+exports.runFixture = function(name, cb) {
+  var suitePath = 'test/fixture/' + name
+    , result = { code: 0, stdout: '', stderr: '' }
+    , mocha;
+
+  mocha = spawn(mochaBin, [ '--reporter', '../../../index.js', suitePath ]);
+
+  mocha.stdout.on('data', function (data) {
+    result.stdout += data.toString();
+  });
+
+  mocha.stderr.on('data', function (data) {
+    result.stderr += data.toString();
+  });
+
+  mocha.on('close', function (code) {
+    result.code = code;
+    cb(result);
+  });
+};

--- a/test/output.spec.js
+++ b/test/output.spec.js
@@ -1,0 +1,16 @@
+var runFixture = require('./lib/util').runFixture
+  , fs = require('fs');
+
+describe('output', function () {
+  afterEach(function () {
+    delete process.env.XUNIT_FILE;
+  });
+
+  it('should write the report to the path specified by the XUNIT_FILE environment variable', function (done) {
+    process.env.XUNIT_FILE = '_tmp/out/target.xml';
+    runFixture('success', function () {
+      var reportExists = fs.existsSync('_tmp/out/target.xml');
+      (reportExists) ? done() : done(new Error('Report not found'));
+    })
+  });
+});


### PR DESCRIPTION
Thanks for this very useful reporter!  I've made a small tweak to ensure the destination folder is created if it does not exist.

* Generate missing folders when `XUNIT_FILE` is specified
* Small refactor to ensure the file descriptor is not created (ie: `fs.open`) until the reporter instance is instantiated.
* Add basic test-coverage to ensure the file is generated at the expected destination.
* Bumped package version to 0.0.7 as there is no API change.