### PR TITLE
Dynamic file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To change the output and activate terminal output, you can create a `config.json
 **config.json**
 ```
 {
-    "file" : "xunit.xml",
+    "file" : "${cwd}/xunit.xml",
     "consoleOutput" : {
       "suite" : true,
       "test" : true,
@@ -65,6 +65,29 @@ Add the following to the xml report.
 </properties>
 ```
 
+**File Path Options**
+
+The file path accepts a few custom tokens to allow creation of dynamic file names.  This can be useful for multithreaded testing (such as using a Selenium Grid) or to keep multiple files by timestamp.  Tokens are in the following format:
+
+```
+${tokenName: 'Token Data'}
+```
+
+The available tokens are `pid` to inject the process id, `cwd` to inject the current working directory, and `ts` or `timestamp` to inject a timestamp.
+
+By default `ts` and `timestamp` use the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format, ex: `2016-03-31T07:27:48+00:00`.  However, if you specify a custom format in the Token Data, the timestamp uses the [node dateformat](https://github.com/felixge/node-dateformat) library to output a string in that format.
+
+A full example `config.json` is as follows:
+
+```
+{
+  "file": "${cwd}/${timestamp: 'MMDD-hhmm'}/xunit-${pid}.xml"
+}
+```
+
+This would output something like `~/myProject/1217-1507/xunit-1234.xml`.  This example would keep copies good for a year without collision, and group multithreaded results by test run.
+
+Tokens can be used in either environment variables or a config.json. The default filepath is always `${cwd}/xunit.xml`.
 
 # Credits
 This reporter is just the original [xunit reporter](https://github.com/visionmedia/mocha/blob/master/lib/reporters/xunit.js) from mocha only writing the result in an xml file.

--- a/lib/file-path-parser.js
+++ b/lib/file-path-parser.js
@@ -1,0 +1,36 @@
+// Exports a factory for testing purposes.
+// Otherwise process will be the real deal.
+// Also, testing with time/timezones is rather difficult, so that's all mocked.
+module.exports = function(myProcess, myDate, myFormatter) {
+  return function(s) {
+    r = s;
+    var now = myDate.now();
+    var pidRE = regexTokenCreator('pid');
+    var cwdRE = regexTokenCreator('cwd');
+    var simpleTSRE = regexTokenCreator('(?:ts|timestamp)');
+    var customTSRE = regexTokenCreator('(?:ts|timestamp):\\s*["\']([^"\']*)["\']');
+
+    r = r.replace(pidRE, myProcess.pid);
+    r = r.replace(cwdRE, myProcess.cwd());
+    r = r.replace(simpleTSRE, myFormatter(now, 'isoDateTime'));
+
+    // collect all of our regex matches
+    var matches = [];
+    var match;
+    while ((match = customTSRE.exec(r)) !== null) {
+      matches.push(match);
+    }
+
+    // Use each match to replace the whole with the date in the format of the
+    // first matching group (the contents of the quotes).
+    matches.forEach(function(match) {
+      r = r.replace(match[0], myFormatter(now, match[1]));
+    });
+
+    return r;
+  }
+}
+
+function regexTokenCreator(s) {
+  return new RegExp('\\${\\s*' + s + '\\s*}', 'ig');
+}

--- a/lib/file-path-parser.js
+++ b/lib/file-path-parser.js
@@ -2,32 +2,33 @@
 // Otherwise process will be the real deal.
 // Also, testing with time/timezones is rather difficult, so that's all mocked.
 module.exports = function(myProcess, myDate, myFormatter) {
-  return function(s) {
-    r = s;
+  return function(pathTemplate) {
     var now = myDate.now();
     var pidRE = regexTokenCreator('pid');
     var cwdRE = regexTokenCreator('cwd');
     var simpleTSRE = regexTokenCreator('(?:ts|timestamp)');
     var customTSRE = regexTokenCreator('(?:ts|timestamp):\\s*["\']([^"\']*)["\']');
-
-    r = r.replace(pidRE, myProcess.pid);
-    r = r.replace(cwdRE, myProcess.cwd());
-    r = r.replace(simpleTSRE, myFormatter(now, 'isoDateTime'));
-
-    // collect all of our regex matches
     var matches = [];
     var match;
-    while ((match = customTSRE.exec(r)) !== null) {
+
+    //process the template to get the final path
+    path = pathTemplate;
+    path = path.replace(pidRE, myProcess.pid);
+    path = path.replace(cwdRE, myProcess.cwd());
+    path = path.replace(simpleTSRE, myFormatter(now, 'isoDateTime'));
+
+    // collect all of our regex matches
+    while ((match = customTSRE.exec(path)) !== null) {
       matches.push(match);
     }
 
     // Use each match to replace the whole with the date in the format of the
     // first matching group (the contents of the quotes).
     matches.forEach(function(match) {
-      r = r.replace(match[0], myFormatter(now, match[1]));
+      path = path.replace(match[0], myFormatter(now, match[1]));
     });
 
-    return r;
+    return path;
   }
 }
 

--- a/lib/xunit-file.js
+++ b/lib/xunit-file.js
@@ -10,7 +10,9 @@ var mocha = require("mocha")
   , fs = require("fs")
   , path = require("path")
   , mkdirp = require("mkdirp")
-  , filePath = process.env.XUNIT_FILE || config.file || process.cwd() + "/xunit.xml"
+  , dateFormat = require('dateformat')
+  , filePathParser = require('./file-path-parser')(process, global.Date, dateFormat)
+  , filePath = filePathParser(process.env.XUNIT_FILE || config.file || "${cwd}/xunit.xml")
   , consoleOutput = config.consoleOutput || {};
 
 /**

--- a/package.json
+++ b/package.json
@@ -30,10 +30,12 @@
   "repository": "git://github.com/peerigon/xunit-file.git",
   "license": "MIT",
   "dependencies": {
+    "dateformat": "^1.0.12",
     "mkdirp": "^0.5.1"
   },
   "devDependencies": {
-    "mocha": "^2.2.5"
+    "mocha": "^2.2.5",
+    "sinon": "^1.17.3"
   },
   "scripts": {
     "test": "rm -rf _tmp && mocha test/*.spec.js"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     {
       "name": "Peter Janes",
       "email": "peter.janes@ek3.com"
+    },
+    {
+      "name": "Nathan Fairhurst",
+      "email": "nathan.p3pictures@gmail.com"
     }
   ],
   "keywords": [

--- a/test/file-path-parser.spec.js
+++ b/test/file-path-parser.spec.js
@@ -1,0 +1,92 @@
+var parserFactory = require('../lib/file-path-parser.js');
+var sinon = require('sinon');
+var expect = require('chai').expect;
+
+describe('file-path-parser', function() {
+  var testTime;
+  var parser;
+  var mockProcess;
+  var mockDate;
+  var mockFormatter;
+
+  beforeEach(function() {
+    testTime = 1459546726107;
+    mockProcess = {};
+    mockProcess.pid = 'mockpid123';
+    mockProcess.cwd = function() { return '/my/mock/cwd'; };
+
+    mockDate = {};
+    mockDate.now = function() { return testTime; };
+
+    mockFormatter = sinon.stub();
+    mockFormatter.returnsArg(1);
+    mockFormatter.withArgs(testTime, 'isoDateTime').returns('defaultTS');
+
+    parser = parserFactory(mockProcess, mockDate, mockFormatter);
+  });
+
+  it('should add in the current working directory', function() {
+    var input = '${cwd}/xunit.xml';
+    var output = parser(input);
+    expect(output).to.equal('/my/mock/cwd/xunit.xml');
+  });
+
+  it('should be able to add in the process id', function() {
+    var input = '~/myProject/xunit-${pid}.xml';
+    var output = parser(input);
+    expect(output).to.equal('~/myProject/xunit-mockpid123.xml');
+  });
+
+  it('should be able to add in multiple process ids', function() {
+    var input = '~/myProject/xunit/${pid}/report-${pid}.xml';
+    var output = parser(input);
+    expect(output).to.equal('~/myProject/xunit/mockpid123/report-mockpid123.xml');
+  });
+
+  it('should be able to add a default timestamp with shorthand', function() {
+    var input = '~/myProject/xunit-${ts}.xml';
+    var output = parser(input);
+    expect(output).to.equal('~/myProject/xunit-defaultTS.xml');
+  });
+
+  it('should be able to add a default timestamp with longform', function() {
+    var input = '~/myProject/xunit-${timestamp}.xml';
+    var output = parser(input);
+    expect(output).to.equal('~/myProject/xunit-defaultTS.xml');
+  });
+
+  it('should be able to add in multiple default timestamps', function() {
+    var input = '~/myProject/xunit/${ts}/report-${timestamp}.xml';
+    var output = parser(input);
+    expect(output).to.equal('~/myProject/xunit/defaultTS/report-defaultTS.xml');
+  });
+
+  it('should be able to add in custom timestamps using double quotes and short form', function() {
+    var input = '~/myProject/xunit-${ts: "M"}.xml';
+    var output = parser(input);
+    expect(output).to.equal('~/myProject/xunit-M.xml');
+    expect(mockFormatter.calledWith(testTime, 'M')).to.be.true;
+  });
+
+  it('should be able to add in custom timestamps using single quotes and long form', function() {
+    var input = '~/myProject/xunit-${timestamp: \'yyss\'}.xml';
+    var output = parser(input);
+    expect(output).to.equal('~/myProject/xunit-yyss.xml');
+    expect(mockFormatter.calledWith(testTime, 'yyss')).to.be.true;
+  });
+
+  it('should be able to add in multiple custom timestamps', function() {
+    var input = '~/myProject/xunit/${ts: \'yyyy\'}/report-${timestamp:"ddmmss"}.xml';
+    var output = parser(input);
+    expect(output).to.equal('~/myProject/xunit/yyyy/report-ddmmss.xml');
+    expect(mockFormatter.calledWith(testTime, 'yyyy')).to.be.true;
+    expect(mockFormatter.calledWith(testTime, 'ddmmss')).to.be.true;
+  });
+
+  it('should put it all together', function() {
+    var input = '${cwd}/${pid}/p-${pid}/time-${ts}/xunit-${timestamp:    "mmdd"   }.xml';
+    var output = parser(input);
+    expect(output).to.equal('/my/mock/cwd/mockpid123/p-mockpid123/time-defaultTS/xunit-mmdd.xml');
+    expect(mockFormatter.calledWith(testTime, 'mmdd')).to.be.true;
+  });
+});


### PR DESCRIPTION
Fully backwards compatible and tested way to allow custom file names with dynamic timestamps/process ids.  The latter is for supporting testing that spins up child process (such as selenium grid testing).

Happy to make changes from feedback.