### PR TITLE
New environment variable XUNIT_SILENT to remove all terminal output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ To change the output and activate terminal output, you can create a `config.json
 ```
 $ XUNIT_FILE=output/xunit.xml mocha -R xunit-file // writes result to output/xunit.xml
 $ LOG_XUNIT=true mocha -R xunit-file // activates terminal output
+$ XUNIT_SILENT=true mocha -R xunit-file // disable all terminal output
 ```
 
 Set XUNIT_LOG_ENV environment variable, if you want the output process and environment variables in the properties section of the xml file.

--- a/lib/xunit-file.js
+++ b/lib/xunit-file.js
@@ -11,7 +11,7 @@ var mocha = require("mocha")
   , path = require("path")
   , mkdirp = require("mkdirp")
   , filePath = process.env.XUNIT_FILE || config.file || process.cwd() + "/xunit.xml"
-  , consoleOutput = config.consoleOutput || {};
+  , consoleOutput = process.env.XUNIT_SILENT ? {} : config.consoleOutput || {};
 
 /**
  * Save timer references to avoid Sinon interfering (see GH-237).


### PR DESCRIPTION
I needed to remove completly the terminal output because I want to use another reporter to show tests results in the terminal.

Not sure if it is the best way to do that. Maybe you will have a better suggestion.

I could not run unit tests on my computer, I have an error when spawning mocha. I'm on Windows. Can you run tests for me to be sure I broke anything?

Thanks