### PR TITLE
fix: Remove escaping character in CDATA

### DIFF
--- a/lib/xunit-file.js
+++ b/lib/xunit-file.js
@@ -89,7 +89,7 @@ function XUnitFile(runner) {
     if( process.env.XUNIT_LOG_ENV) {
       logProperties(fd);
     }
-  
+
     tests.forEach(function(test){
       writeTest(fd, test);
     });
@@ -106,7 +106,7 @@ function XUnitFile(runner) {
 XUnitFile.prototype.__proto__ = Base.prototype;
 
 /**
- * Writes a list of process and environment variables to the <properties> section in the XML. 
+ * Writes a list of process and environment variables to the <properties> section in the XML.
  */
 function logProperties(fd) {
   var attrs = new Object();
@@ -131,7 +131,7 @@ function logProperties(fd) {
 }
 
 /**
- * Formats a single property value. 
+ * Formats a single property value.
  */
 
 function logProperty( name, value) {
@@ -139,7 +139,7 @@ function logProperty( name, value) {
 }
 
 /**
- * Simple utility to convert a flat Object to a readable string. 
+ * Simple utility to convert a flat Object to a readable string.
  */
 
 function objectToString( obj) {
@@ -200,11 +200,11 @@ function tag(name, attrs, close, content) {
 }
 
 /**
- * Return cdata escaped CDATA `str`.
+ * Return CDATA `str`.
  */
 
 function cdata(str) {
-  return '<![CDATA[' + escape(str) + ']]>';
+  return '<![CDATA[' + str + ']]>';
 }
 
 function appendLine(fd, line) {


### PR DESCRIPTION
Special characters do not have to be escaped in CDATA, it causes double escape when we try to publish the output.

http://stackoverflow.com/questions/2784183/what-does-cdata-in-xml-mean
