### PR TITLE
fix: Dont count xunit failures as errors

### DIFF
--- a/lib/xunit-file.js
+++ b/lib/xunit-file.js
@@ -80,7 +80,7 @@ function XUnitFile(runner) {
         name: process.env.SUITE_NAME || 'Mocha Tests'
       , tests: stats.tests
       , failures: stats.failures
-      , errors: stats.failures
+      , errors: 0
       , skipped: stats.tests - stats.failures - stats.passes
       , timestamp: timestampStr
       , time: stats.duration / 1000


### PR DESCRIPTION
Per http://reflex.gforge.inria.fr/xunit.html#xunitReport a failure and an error are different concepts and must be counted as such. Some parsers will fail if the number of expected tests do not add up.

Related change in repo from which this was copied: https://github.com/mochajs/mocha/pull/2475
