### PR TITLE
Make xunit-file configurable from grunt or gulp

### DIFF
--- a/lib/xunit-file.js
+++ b/lib/xunit-file.js
@@ -12,8 +12,6 @@ var mocha = require("mocha")
   , mkdirp = require("mkdirp")
   , dateFormat = require('dateformat')
   , filePathParser = require('./file-path-parser')(process, global.Date, dateFormat)
-  , filePath = filePathParser(process.env.XUNIT_FILE || config.file || "${cwd}/xunit.xml")
-  , consoleOutput = process.env.XUNIT_SILENT ? {} : config.consoleOutput || {};
 
 /**
  * Save timer references to avoid Sinon interfering (see GH-237).
@@ -35,14 +33,20 @@ exports = module.exports = XUnitFile;
  * Initialize a new `XUnitFile` reporter.
  *
  * @param {Runner} runner
+ * @param {???} options
  * @api public
  */
 
-function XUnitFile(runner) {
+function XUnitFile(runner, options) {
   Base.call(this, runner);
   var stats = this.stats
     , tests = []
     , fd;
+
+  var reporterOptions = options.reporterOptions || {};
+
+  filePath = filePathParser(reporterOptions.filePath || process.env.XUNIT_FILE || config.file || "${cwd}/xunit.xml")
+  consoleOutput = reporterOptions.consoleOutput || process.env.XUNIT_SILENT ? {} : config.consoleOutput || {};
 
   mkdirp.sync(path.dirname(filePath));
   fd = fs.openSync(filePath, 'w', 0755);

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "mkdirp": "^0.5.1"
   },
   "devDependencies": {
+    "chai": "^3.5.0",
     "mocha": "^2.2.5",
     "sinon": "^1.17.3"
   },

--- a/test/output.spec.js
+++ b/test/output.spec.js
@@ -1,4 +1,6 @@
 var runFixture = require('./lib/util').runFixture
+  , Mocha = require('mocha')
+  , gulp = require('gulp')
   , fs = require('fs');
 
 describe('output', function () {
@@ -12,5 +14,16 @@ describe('output', function () {
       var reportExists = fs.existsSync('_tmp/out/target.xml');
       (reportExists) ? done() : done(new Error('Report not found'));
     })
+  });
+
+  it('should write the report to the path specified by {"xunitFile": "value"}', function(done) {
+    var mocha = new Mocha({'reporter': '../../../index.js', 'reporterOptions': {'filePath': '_tmp/out/test.xml' }});
+
+    mocha.addFile('test/fixture/success/success.spec');
+
+    mocha.run(function(failures) {
+      var reportExists = fs.existsSync('_tmp/out/test.xml');
+      (reportExists) ? done() : done(new Error('Report not found'));
+    });
   });
 });


### PR DESCRIPTION
I have multiple test suites runnable from gulp (unit, regression, integration) which I'd like to output to different files.  There was no straightforward way to do this using xunit-file.

New functionality had been added to the upstream project (xunit) to support configuration from a test runner like grunt or gulp.  I used their implementation to guide my own here.

Also adding in missing chai dev dependency.