### PR TITLE
Updating dateformat to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "repository": "git://github.com/peerigon/xunit-file.git",
   "license": "MIT",
   "dependencies": {
-    "dateformat": "^1.0.12",
+    "dateformat": "^2.0.0",
     "mkdirp": "^0.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
`dateformat` v2 is out. The only change between 1.0.12 and 2.0.0 is the removal of the CLI, which removes dependencies and doesn't affect this project.

See https://github.com/felixge/node-dateformat/pull/53