### PR TITLE
chore: add chai as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "mkdirp": "^0.5.1"
   },
   "devDependencies": {
+    "chai": "^4.1.2",
     "mocha": "^2.2.5",
     "sinon": "^1.17.3"
   },


### PR DESCRIPTION
Required by the tests.
Like this we avoid to install chai as a global module.