### PR TITLE
relax package.json engine restriction to allow v18

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -27,5 +27,4 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
-    - run: npm run build --if-present
     - run: npm test

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "test": "rm -rf _tmp && mocha test/*.spec.js"
   },
   "engines": {
-    "node": ">= 12.0.0 <= 16"
+    "node": ">= 12.0.0"
   }
 }


### PR DESCRIPTION
Node.js 18 is going to be LTS in the next few days.

While starting testing our platform for node.js 18 migration we have found the following warning running `npm ci`:

```sh
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'xunit-file@2.0.0',
npm WARN EBADENGINE   required: { node: '>= 12.0.0 <= 16' },
npm WARN EBADENGINE   current: { node: 'v18.11.0', npm: '8.19.2' }
npm WARN EBADENGINE }
```
I am submitting this PR to relax the restriction in package.json to allow node.js 18 and 19.

As part of this I have added node.js 18 in github CI action and removed `npm run build --if-present` step as I found it is not present in this project (there is no typescript or any tool that requires a transpilation or build phase).

I have runned locally with node.js 18  `npm t` and all tests are green.

Would love to hear any feedback on this.

Thank you
